### PR TITLE
[maintenance] indicate that integration has been moved to dagster-io/community-integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This integration has been moved to [dagster-io/community-integrations](https://github.com/dagster-io/community-integrations/tree/main/libraries/dagster-hightouch). Please open new pull requests and issues in that repository instead. Thank you!
+
 [![Pypi Publish](https://github.com/hightouchio/dagster-hightouch/actions/workflows/pypi-publish.yml/badge.svg)](https://github.com/hightouchio/dagster-hightouch/actions/workflows/pypi-publish.yml)
 
 ## Dagster-Hightouch


### PR DESCRIPTION
Closes https://github.com/hightouchio/dagster-hightouch/issues/3

---

Renders as:
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/61c70016-0fed-4cc0-b6bd-2b7cd321ac17">
